### PR TITLE
add ignore field

### DIFF
--- a/tagalyzer.go
+++ b/tagalyzer.go
@@ -10,6 +10,10 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
+const (
+	TAG_IGNORE_FIELD = `tagalyzer:"-"`
+)
+
 // Tags allow passing multiple values to the same command line flag
 type Tags []string
 
@@ -76,6 +80,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		s := n.(*ast.StructType)
 
 		for _, f := range s.Fields.List {
+			// if struct field contains `tagalyzer:"-"`, then ignore it
+			// don't do any analysis on such fields
+			if f.Tag != nil && strings.Contains(f.Tag.Value, TAG_IGNORE_FIELD) {
+				continue
+			}
+
 			for _, tag := range tags {
 				if f.Tag == nil || !strings.Contains(f.Tag.Value, tag) {
 					var fieldName string

--- a/tagalyzer_test.go
+++ b/tagalyzer_test.go
@@ -14,6 +14,9 @@ func TestTagalyzer(t *testing.T) {
 	Analyzer.Flags.Set("tag", "json")
 	analysistest.Run(t, analysistest.TestData(), Analyzer, "onetag.go")
 
+	// test ignore field using `tagalyzer:"-"`
+	analysistest.Run(t, analysistest.TestData(), Analyzer, "ignorefield.go")
+
 	// test with embedded fields, first ignore embedded
 	analysistest.Run(t, analysistest.TestData(), Analyzer, "ignoreembedded.go")
 

--- a/testdata/ignorefield.go
+++ b/testdata/ignorefield.go
@@ -1,0 +1,7 @@
+package testdata
+
+type IgnoreField struct {
+	Name string // want "field:Name is missing tag:json"
+	Age  int    // want "field:Age is missing tag:json"
+	ssn  string `tagalyzer:"-"`
+}


### PR DESCRIPTION
closes #4 

Added support for skipping/ignoring analysis on struct fields using `tagalyzer:"-"`

Example:
```go
type User struct {
    Name string `json:"name"`
    ssn string `tagalyzer:"-"`
}
```

Running the analyzer on the example above will skip analysis on the ssn field. 